### PR TITLE
update versioning workflow with new PAT

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -100,7 +100,7 @@ jobs:
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GHCR_PAT_WRITE_PACKAGE }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       # Build and push Docker image with version and latest tags
       - name: Build and push Docker image


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/versioning.yml` file. The change updates the secret used for logging into the GitHub Container Registry to use `GHCR_PAT_WRITE_PACKAGE` instead of `GHCR_PAT`.

* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68L103-R103): Updated the secret for Docker login to `GHCR_PAT_WRITE_PACKAGE` for improved security.