### PR TITLE
Fix/apple

### DIFF
--- a/src/job_scrapers/apple.py
+++ b/src/job_scrapers/apple.py
@@ -56,7 +56,6 @@ class AppleJobScraper(JobScraperBase):
             except Exception:
                 pass
 
-            # Extract the total-offers number (e.g. "200 résultat(s)")
             try:
                 total_offers_text = (
                     WebDriverWait(self.driver, 15)
@@ -133,12 +132,6 @@ class AppleJobScraper(JobScraperBase):
                     )
                     time.sleep(random.uniform(1, 2))
 
-                    # The "next page" button no longer uses "li.pagination__next a[...]"
-                    # In your pasted HTML, the next button is:
-                    #   <button class="icon icon-chevronend" type="button" ...>
-                    #   or:
-                    #   <button aria-label="Page suivante" class="icon icon-chevronend" ...>
-                    # So we wait for that instead:
                     next_button = WebDriverWait(self.driver, 10).until(
                         EC.element_to_be_clickable(
                             (

--- a/src/offer_processor.py
+++ b/src/offer_processor.py
@@ -104,7 +104,7 @@ class OfferProcessor:
                     f"URL: {offer['URL']}\n"
                 )
             self.sms_client.send_sms(sms_message)
-            time.sleep(3)
+            time.sleep(10)
 
             job_properties = {
                 "Title": {

--- a/tests/unit/test_apple_scraper.py
+++ b/tests/unit/test_apple_scraper.py
@@ -17,8 +17,6 @@ def apple_scraper():
         # Monkey-patch missing methods from the source code.
         scraper.should_skip_offer = lambda job_title: False
         scraper._init_offer_dict = lambda: {}
-        # Also add extract_total_offers method to the instance.
-        scraper.extract_total_offers = lambda: scraper.total_offers
         return scraper
 
 
@@ -33,69 +31,87 @@ def test_apple_setup_driver():
 
 def test_apple_load_all_offers(apple_scraper):
     apple_scraper.include_filters = ["offer"]
+
+    # Setup mocks
     dummy_cookie = MagicMock()
-    dummy_total_element = MagicMock(text="1 offers")
+    dummy_total_element = MagicMock(text="100 résultat(s)")
     dummy_offer_presence = MagicMock()
+
+    # Setup accordion item
     dummy_row = MagicMock()
     dummy_title_link = MagicMock()
     dummy_title_link.text = "Offer Title"
     dummy_title_link.get_attribute.return_value = "http://offer1"
+
+    # Mock find_element for the link
     dummy_row.find_element.return_value = dummy_title_link
+
+    # Mock find_elements for rows
     apple_scraper.driver.find_elements.return_value = [dummy_row]
+
+    # Setup next button
+    next_button = MagicMock()
+
     with patch("selenium.webdriver.support.ui.WebDriverWait") as mock_wait:
         instance = MagicMock()
         # The sequence below simulates:
         # 1. Clicking cookie consent,
-        # 2. Waiting for first offer,
-        # 3. Finding the total offers element,
-        # 4. Waiting again inside the loop,
-        # 5. And then failing to find a next button.
+        # 2. Finding the total offers element,
+        # 3. Waiting for first offer,
+        # 4. Finding the next button,
+        # 5. And then failing to find a next button on next iteration.
         instance.until.side_effect = [
             dummy_cookie,  # cookie consent click
-            dummy_offer_presence,  # wait for offer title presence
-            dummy_total_element,  # total offers element (text "1 offers")
-            dummy_offer_presence,  # wait inside loop for offer title
-            Exception("No next button"),
+            dummy_total_element,  # total offers element
+            dummy_offer_presence,  # wait for offer presence
+            next_button,  # next button
+            Exception("No more next button"),  # timeout on next iteration
         ]
         mock_wait.return_value = instance
-        apple_scraper.load_all_offers()
-    assert apple_scraper.total_offers == 1
+
+        # Mock the regex search
+        with patch("re.search") as mock_search:
+            mock_search.return_value = MagicMock()
+            mock_search.return_value.group.return_value = "100"
+
+            apple_scraper.load_all_offers()
+
+    assert apple_scraper.total_offers == 100
     assert len(apple_scraper.offers_url) == 1
     assert apple_scraper.offers_url[0] == "http://offer1"
 
 
 def test_apple_extract_offers(apple_scraper):
     apple_scraper.offers_url = ["http://offer1", "http://offer2"]
-    dummy_elements = [
-        # Offer 1 elements
-        MagicMock(text="Title1"),
-        MagicMock(text="Ref1"),
-        MagicMock(text="City1, Country"),
-        MagicMock(text="40 hours"),
-        MagicMock(text="Team1"),
-        MagicMock(text="Description1"),
-        MagicMock(text="MinQual1"),
-        MagicMock(text="PrefQual1"),
-        # Offer 2 elements
-        MagicMock(text="Title2"),
-        MagicMock(text="Ref2"),
-        MagicMock(text="City2, Country"),
-        MagicMock(text="35 hours"),
-        MagicMock(text="Team2"),
-        MagicMock(text="Description2"),
-        MagicMock(text="MinQual2"),
-        MagicMock(text="PrefQual2"),
-    ]
-    apple_scraper.driver.find_element.side_effect = dummy_elements
+
+    # Setup the mocked find_element function to return appropriate values for each element ID
+    def mock_find_element(by, selector):
+        elements = {
+            "jobdetails-postingtitle": MagicMock(text="Title"),
+            "jobdetails-jobnumber": MagicMock(text="Ref"),
+            "jobdetails-joblocation": MagicMock(text="City, Country"),
+            "jobdetails-weeklyhours": MagicMock(text="40 hours"),
+            "jobdetails-teamname": MagicMock(text="Team"),
+            "jobdetails-jobdetails-jobsummary-content-row": MagicMock(text="Summary"),
+            "jobdetails-jobdetails-jobdescription-content-row": MagicMock(
+                text="Description"
+            ),
+            "jobdetails-jobdetails-minimumqualifications-content-row": MagicMock(
+                text="MinQual"
+            ),
+            "jobdetails-jobdetails-preferredqualifications-content-row": MagicMock(
+                text="PrefQual"
+            ),
+        }
+        return elements.get(selector, MagicMock(text="N/A"))
+
+    apple_scraper.driver.find_element.side_effect = mock_find_element
+
     offers = apple_scraper.extract_offers()
+
     assert len(offers) == 2
-    assert offers[0]["Title"] == "Title1"
-    assert offers[0]["Location"] == "City1"
+    assert offers[0]["Title"] == "Title"
+    assert offers[0]["Location"] == "City, Country"
     assert offers[0]["URL"] == "http://offer1"
     assert offers[0]["Source"] == "Apple"
-
-
-def test_apple_extract_total_offers(apple_scraper):
-    apple_scraper.total_offers = 5
-    total = apple_scraper.extract_total_offers()
-    assert total == 5
+    assert offers[0]["Company"] == "Apple"


### PR DESCRIPTION
This pull request includes several updates to the job scrapers for Apple and Welcome to the Jungle, as well as adjustments to the offer processing and unit tests. The most important changes focus on improving the reliability of the scrapers and enhancing the test coverage.

### Improvements to job scrapers:

* [`src/job_scrapers/apple.py`](diffhunk://#diff-0cf6b1646f0fb50435686901fc8ab3d3c4d329fe4bed0ef6b66a9d1ff3427318R2-R7): Added handling for `TimeoutException` and updated the method for extracting the total number of offers using regex. Adjusted the selectors to match the updated website structure and improved the logic for navigating through job offers. [[1]](diffhunk://#diff-0cf6b1646f0fb50435686901fc8ab3d3c4d329fe4bed0ef6b66a9d1ff3427318R2-R7) [[2]](diffhunk://#diff-0cf6b1646f0fb50435686901fc8ab3d3c4d329fe4bed0ef6b66a9d1ff3427318L45-R50) [[3]](diffhunk://#diff-0cf6b1646f0fb50435686901fc8ab3d3c4d329fe4bed0ef6b66a9d1ff3427318L65-R158) [[4]](diffhunk://#diff-0cf6b1646f0fb50435686901fc8ab3d3c4d329fe4bed0ef6b66a9d1ff3427318L187-R220)
* [`src/job_scrapers/welcome_to_the_jungle.py`](diffhunk://#diff-dc19ee754afa8db50121eb04ed34a9287b7c872332c116bacd113d661596affdR132-R151): Updated selectors to be more robust by using attributes like `aria-label`. Improved error handling for missing job links and titles. [[1]](diffhunk://#diff-dc19ee754afa8db50121eb04ed34a9287b7c872332c116bacd113d661596affdR132-R151) [[2]](diffhunk://#diff-dc19ee754afa8db50121eb04ed34a9287b7c872332c116bacd113d661596affdL157-R191) [[3]](diffhunk://#diff-dc19ee754afa8db50121eb04ed34a9287b7c872332c116bacd113d661596affdL235-R277) [[4]](diffhunk://#diff-dc19ee754afa8db50121eb04ed34a9287b7c872332c116bacd113d661596affdL261-R298)

### Enhancements to offer processing:

* [`src/offer_processor.py`](diffhunk://#diff-b82879d75a635a94c44c06df651e595be8aea2d4750063be1e2488357b34159bL107-R107): Increased the sleep time between processing offers from 3 seconds to 10 seconds to prevent rate limiting.

### Updates to unit tests:

* [`tests/unit/test_apple_scraper.py`](diffhunk://#diff-ea6206e71c2cb4591e38f3ada64ecb6dc7082464aae81c012a4bb16e394f9968L20-L21): Removed the unnecessary `extract_total_offers` method and added comprehensive mocks to simulate various scenarios in the `test_apple_load_all_offers` and `test_apple_extract_offers` tests. [[1]](diffhunk://#diff-ea6206e71c2cb4591e38f3ada64ecb6dc7082464aae81c012a4bb16e394f9968L20-L21) [[2]](diffhunk://#diff-ea6206e71c2cb4591e38f3ada64ecb6dc7082464aae81c012a4bb16e394f9968R34-R117)

These changes aim to enhance the reliability and maintainability of the job scrapers and ensure more robust testing.